### PR TITLE
[update] MIP-0 : Introduce status terms and editor role

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An MIP is proposed through a PR. Each MIP-introducing PR should have a status in
 
 An MIP should at all times have one of the following statuses:
 - **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
-- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, the MIP should be registered in the MIP overview file.
+- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**.
 - **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
 
 >[!Note]

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ MIPs, MDs and MGs are assigned their PR number as soon as they are drafted. MDs 
 ## Status Terms
 
 A MIP is proposed through a PR. It should at all times have one of the following statuses:
-- **Draft** - an MIP that is open for consideration. (It does not yet hold a MIP number)
-- **Review** - The MIP is under peer review. The MIP should receive an **MIP number** and the MIP should be registered in the MIP overview file.
-- **Accepted** - an MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
+- **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold a MIP number)
+- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number** and the MIP should be registered in the MIP overview file.
+- **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
 
 After acceptance the MIP is merged into `main` and the branch should be deleted.
 

--- a/README.md
+++ b/README.md
@@ -55,23 +55,27 @@ PRs that don't introduce a new MIP are also accepted.
 MIPs can be updated. PRs that update a MIP should state so in the PR title via `[Update] .... `. 
 
 ## Status Terms
+
 An MIP is proposed through a PR. Each MIP-introducing PR should have a status in the name in the form `[Status] ...`.
 
 An MIP/MG should at all times have one of the following statuses:
+
 - **Draft** - (set by author) An MIP/MG that is open for consideration. (It does not yet hold an MIP/MG number)
 - **Review** - (set by author) The MIP/MG is under peer review. The MIP should receive an **MIP number**, according to the rules described in the [Files and numbering](#files-and-numbering) section. At this point the editor should be involved to ensure the MIP adheres to the guidelines.
 
 >[!Note]
-> In case the editors are not available for an unacceptable long period of time, a reviewer should assume the role of the editor interim. 
+> In case the editors are not available for an unacceptable long period of time, a reviewer should assume the role of the editor interim.
 
 After acceptance the MIP is merged into `main` and the branch should be deleted.
 
-Addtionally, the following statuses are used for MIPs that are not actively being worked on:
+Additionally, the following statuses are used for MIPs that are not actively being worked on:
+
 - **Stagnant** - an MIP that has not been updated for 6 months.
 - **Withdrawn** - an MIP that has not been withdrawn.
 
 
 Finally, MIPs can also be updated
+
 - **Update** - (set by author) An MIP is being updated. The titel should list the MIP number, e.g. `[Update] MIP-0 ...`.
 
 
@@ -79,18 +83,20 @@ Finally, MIPs can also be updated
 
 The motivation for the role of the editor is to ensure the readability and easy access of content, until further means, such as automatic rendering becomes available.
 
-Currently the editors are [@apenzk](https://github.com/apenzk). 
+Currently the editors are [@apenzk](https://github.com/apenzk).
 
 The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
+
 - Ensures a high quality of the MIPs, e.g. checking language while reviewing.
 - Removes content from the MIPs that is commented out. (<!- ->)
 - Ensures the MIP numbering is correct, the MIP has been added to [OVERVIEW.md](./OVERVIEW.md)
-- Ensures the MIP is in the correct status. 
-- Ensures the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS).
+- Ensures the MIP is in the correct status.
+- Ensures the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS), see [Code owners](#code-owners).
 
-The editor is not responsible for the content. 
+The editor is not responsible for the content.
 
 **Conflict resolution**: In the unlikely case, where an editor requests a change from an author that the author does not agree with and communication does not resolve the situation
+
 - the editor can mandate that the author implements the changes by getting 2 upvotes from reviewers on their discussion comment mentioning the changes.
 - Otherwise the author can merge without the editor requested change.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Finally, MIPs can also be updated
 
 ## Editor
 
-Currently the editors are [@andyjsbell](https://github.com/andyjsbell), [@l-monninger](https://github.com/l-monninger), [@apenzk](https://github.com/apenzk). Volunteers are welcome.
+Currently the editors are [@apenzk](https://github.com/apenzk), [@andyjsbell](https://github.com/andyjsbell), [@l-monninger](https://github.com/l-monninger). Volunteers are welcome.
 
 The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
 - Ensures a high quality of the MIPs.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ An MIP is proposed through a PR. Each MIP-introducing PR should have a status in
 
 An MIP should at all times have one of the following statuses:
 - **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
-- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number** and the MIP should be registered in the MIP overview file.
+- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, the MIP should be registered in the MIP overview file, and the author should add themselves in the `CODEOWNERS` file.
 - **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
+
+>[!Note]
+> In case the editors are not available for an unacceptable long period of time, a reviewer should assume the role of the editor interim. 
 
 After acceptance the MIP is merged into `main` and the branch should be deleted.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ An MIP is proposed through a PR. Each MIP-introducing PR should have a status in
 
 An MIP should at all times have one of the following statuses:
 - **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
-- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**.
+- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, determined by the author.
+
+>[!Note]
+> Currently the author has to understand from the PRs what the latest MIP number is. This is suboptimal and will be fixed by a later PR. 
+
 - **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
 
 >[!Note]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An MIP is proposed through a PR. Each MIP-introducing PR should have a status in
 
 An MIP should at all times have one of the following statuses:
 - **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
-- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, determined by the author.
+- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, according to the rules described in the [Files and numbering](#files-and-numbering) section.
 
 >[!Note]
 > Currently the author has to understand from the PRs what the latest MIP number is. This is suboptimal and will be fixed by a later PR. 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,23 @@ MG serve to capture the **definitions** of terms introduced in the MIPs and MDs.
 
 
 ## Files and numbering
-Each MIP, MD or MG is stored in a separate subdirectory with the a name `mip-<number>`, `md-<number>` or `mg-<number>`. The subdirectory contains a README.md file that describes the MIP, MD, or MG. All assets related to the MIP, MD or MG are stored in the same subdirectory.
 
-MIPs, MDs and MGs are assigned their PR number as soon as they are drafted. MDs that do not introduce a new MIP are also accepted. Thus, there will be gaps in the MIP number sequence. These gaps will also emerge when MIPs are deprecated or rejected.
+Each MIP, MD or MG is stored in a separate subdirectory with the a name `mip-<number>`, `md-<number>` or `mg-<number>`. The subdirectory contains a `README.md` that describes the MIP, MD, or MG. All assets related to the MIP, MD or MG are stored in the same subdirectory.
+
+MIPs start as Drafts. MIPs obtain a number during the review process described in [Status Terms](#status-terms).  
+
+PRs that don't introduce a new MIP are also accepted. 
+
+- MIPs can be updated. PRs that update a MIP should state so in the PR title via `[Update] .... `. 
+
+There may be gaps in the numbering, as MIPs get rejected and removed.
 
 
 ## Status Terms
+An MIP is proposed through a PR. Each MIP-introducing PR should have a status in the name in the form `[Status] ...`.
 
-A MIP is proposed through a PR. It should at all times have one of the following statuses:
-- **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold a MIP number)
+An MIP should at all times have one of the following statuses:
+- **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
 - **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number** and the MIP should be registered in the MIP overview file.
 - **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
 

--- a/README.md
+++ b/README.md
@@ -46,21 +46,20 @@ MG serve to capture the **definitions** of terms introduced in the MIPs and MDs.
 
 Each MIP, MD or MG is stored in a separate subdirectory with the a name `mip-<number>`, `md-<number>` or `mg-<number>`. The subdirectory contains a `README.md` that describes the MIP, MD, or MG. All assets related to the MIP, MD or MG are stored in the same subdirectory.
 
-MIPs start as Drafts. MIPs obtain a number during the review process described in [Status Terms](#status-terms).  
+MIP/MG start as Drafts. They do not need to acquire a number at this point. 
+
+MIPs, MDs and MGs are assigned their PR number as soon as they are in the review process. MDs that do not introduce a new MIP are also accepted. Thus, there will be gaps in the MIP number sequence. These gaps will also emerge when MIPs are deprecated or rejected.
 
 PRs that don't introduce a new MIP are also accepted. 
 
-- MIPs can be updated. PRs that update a MIP should state so in the PR title via `[Update] .... `. 
-
-There may be gaps in the numbering, as MIPs get rejected and removed.
-
+MIPs can be updated. PRs that update a MIP should state so in the PR title via `[Update] .... `. 
 
 ## Status Terms
 An MIP is proposed through a PR. Each MIP-introducing PR should have a status in the name in the form `[Status] ...`.
 
-An MIP should at all times have one of the following statuses:
-- **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
-- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, according to the rules described in the [Files and numbering](#files-and-numbering) section.
+An MIP/MG should at all times have one of the following statuses:
+- **Draft** - (set by author) An MIP/MG that is open for consideration. (It does not yet hold an MIP/MG number)
+- **Review** - (set by author) The MIP/MG is under peer review. The MIP should receive an **MIP number**, according to the rules described in the [Files and numbering](#files-and-numbering) section. At this point the editor should be involved to ensure the MIP adheres to the guidelines.
 
 >[!Note]
 > In case the editors are not available for an unacceptable long period of time, a reviewer should assume the role of the editor interim. 
@@ -93,11 +92,10 @@ The editor is not responsible for the content.
 
 **Conflict resolution**: In the unlikely case, where an editor requests a change from an author that the author does not agree with and communication does not resolve the situation
 - the editor can mandate that the author implements the changes by getting 2 upvotes from reviewers on their discussion comment mentioning the changes.
-- Otherwise the author can request a merge without the change.
+- Otherwise the author can merge without the editor requested change.
 
 
 ## Code owners
 An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 
 This is being implemented by adding the author as a code owner in the `.github/CODEOWNERS` file for a given MIP or MD.
-

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Finally, MIPs can also be updated
 
 ## Editor
 
-Currently the editors are [@apenzk](https://github.com/apenzk), [@andyjsbell](https://github.com/andyjsbell), [@l-monninger](https://github.com/l-monninger). Volunteers are welcome.
+Currently the editors are [@apenzk](https://github.com/apenzk). Volunteers are welcome.
 
 The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
 - Ensures a high quality of the MIPs.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Finally, MIPs can also be updated
 
 ## Editor
 
-Currently the editors are [@apenzk](https://github.com/apenzk). Volunteers are welcome.
+Currently the editors are [@apenzk](https://github.com/apenzk). 
 
 The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
 - Ensures a high quality of the MIPs.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ After acceptance the MIP is merged into `main` and the branch should be deleted.
 
 Addtionally, the following statuses are used for MIPs that are not actively being worked on:
 - **Stagnant** - an MIP that has not been updated for 6 months.
-- **Withdrawn** - an MIP that has not been updated for 6 months.
+- **Withdrawn** - an MIP that has not been withdrawn.
 
 
 Finally, MIPs can also be updated
@@ -77,6 +77,8 @@ Finally, MIPs can also be updated
 
 
 ## Editor
+
+The motivation for the role of the editor is to ensure the readability and easy access of content, until further means, such as automatic rendering becomes available.
 
 Currently the editors are [@apenzk](https://github.com/apenzk). 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An MIP is proposed through a PR. Each MIP-introducing PR should have a status in
 
 An MIP should at all times have one of the following statuses:
 - **Draft** - (set by author) An MIP that is open for consideration. (It does not yet hold an MIP number)
-- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, the MIP should be registered in the MIP overview file, and the author should add themselves in the `CODEOWNERS` file.
+- **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, the MIP should be registered in the MIP overview file.
 - **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
 
 >[!Note]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Each MIP, MD or MG is stored in a separate subdirectory with the a name `mip-<nu
 MIPs, MDs and MGs are assigned their PR number as soon as they are drafted. MDs that do not introduce a new MIP are also accepted. Thus, there will be gaps in the MIP number sequence. These gaps will also emerge when MIPs are deprecated or rejected.
 
 
+## Status Terms
+
+A MIP is proposed through a PR. It should at all times have one of the following statuses:
+- **Draft** - an MIP that is open for consideration. (It does not yet hold a MIP number)
+- **Review** - The MIP is under peer review. The MIP should receive an **MIP number** and the MIP should be registered in the MIP overview file.
+- **Accepted** - an MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
+
+After acceptance the MIP is merged into `main` and the branch should be deleted.
+
+Addtionally, the following statuses are used for MIPs that are not actively being worked on:
+- **Stagnant** - an MIP that has not been updated for 6 months.
+- **Withdrawn** - an MIP that has not been updated for 6 months.
+
+
 ## Code owners
 An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ The editor is responsible for the final review of the MIPs. The editor is respon
 - Ensures the MIP numbering is correct, the MIP has been added to [OVERVIEW.md](./OVERVIEW.md), the MIP is in the correct status and the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS).
 
 
+**Conflict resolution**: If an editor requests a change from an author that the author does not agree with and communication does not resolve the situation
+- the editor can mandate that the author implements the changes by getting 2 upvotes from reviewers on their discussion comment mentioning the changes.
+- Otherwise the author can request a merge without the change.
+
+
 ## Code owners
 An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,6 @@ An MIP should at all times have one of the following statuses:
 - **Review** - (set by author) The MIP is under peer review. The MIP should receive an **MIP number**, according to the rules described in the [Files and numbering](#files-and-numbering) section.
 
 >[!Note]
-> Currently the author has to understand from the PRs what the latest MIP number is. This is suboptimal and will be fixed by a later PR. 
-
-- **Accepted** - (set by editor) An MIP that has been accepted. All technical changes requested have been addressed by the author. There may be additional non-technical changes requested by the MIP editor.
-
->[!Note]
 > In case the editors are not available for an unacceptable long period of time, a reviewer should assume the role of the editor interim. 
 
 After acceptance the MIP is merged into `main` and the branch should be deleted.
@@ -86,10 +81,13 @@ Finally, MIPs can also be updated
 Currently the editors are [@apenzk](https://github.com/apenzk). 
 
 The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
-- Ensures a high quality of the MIPs.
+- Ensures a high quality of the MIPs, e.g. checking language while reviewing.
 - Removes content from the MIPs that is commented out. (<!- ->)
-- Ensures the MIP numbering is correct, the MIP has been added to [OVERVIEW.md](./OVERVIEW.md), the MIP is in the correct status and the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS).
+- Ensures the MIP numbering is correct, the MIP has been added to [OVERVIEW.md](./OVERVIEW.md)
+- Ensures the MIP is in the correct status. 
+- Ensures the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS).
 
+The editor is not responsible for the content.
 
 **Conflict resolution**: If an editor requests a change from an author that the author does not agree with and communication does not resolve the situation
 - the editor can mandate that the author implements the changes by getting 2 upvotes from reviewers on their discussion comment mentioning the changes.
@@ -100,3 +98,4 @@ The editor is responsible for the final review of the MIPs. The editor is respon
 An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 
 This is being implemented by adding the author as a code owner in the `.github/CODEOWNERS` file for a given MIP or MD.
+

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Addtionally, the following statuses are used for MIPs that are not actively bein
 - **Withdrawn** - an MIP that has not been updated for 6 months.
 
 
+Finally, MIPs can also be updated
+- **Update** - (set by author) An MIP is being updated. The titel should list the MIP number, e.g. `[Update] MIP-0 ...`.
+
+
 ## Code owners
 An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ The editor is responsible for the final review of the MIPs. The editor is respon
 - Ensures the MIP is in the correct status. 
 - Ensures the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS).
 
-The editor is not responsible for the content.
+The editor is not responsible for the content. 
 
-**Conflict resolution**: If an editor requests a change from an author that the author does not agree with and communication does not resolve the situation
+**Conflict resolution**: In the unlikely case, where an editor requests a change from an author that the author does not agree with and communication does not resolve the situation
 - the editor can mandate that the author implements the changes by getting 2 upvotes from reviewers on their discussion comment mentioning the changes.
 - Otherwise the author can request a merge without the change.
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,39 @@
 
 # MIP, MD and MG
 
-We differentiate between MD and MIPs. 
+We differentiate between MD and MIPs.
 
 In addition MG serves as a glossary for terms defined in the MIPs and MDs.
 
-## Movement Desiderata (MD) 
+## Movement Desiderata (MD)
 
 See [MD-0](./MD/md-0) to get started. A template is provided at [md-template](md-template.md).
 
-MDs serve to capture the **objectives** behind the **introduction** of a particular MIP.
-Any  
-- _wish_, 
-- _requirement_, or 
-- _need_ 
+MDs serve to capture the **objectives** behind the **introduction** of a particular MIP. Any  
 
-related to MIPs should be documented as an MD and stored in the MD directory. 
+- _wish_,
+- _requirement_, or
+- _need_
+
+related to MIPs should be documented as an MD and stored in the MD directory.
 
 ## Movement Improvement Proposal (MIP)
 
 See [MIP-0](./MIP/mip-0) to get started. A template is provided at [mip-template](mip-template.md).
 
-
 ### Deciding whether to propose
+
 You **SHOULD** draft and submit an MIP, if any of the following are true:
+
 - Governance for the relevant software unit or process requires an MIP.
 - The proposal is complex or fundamentally alters existing software units or processes.
 
-AND, you plan to do the work of fully specifying the proposal and shepherding it through the MIP review process. 
+AND, you plan to do the work of fully specifying the proposal and shepherding it through the MIP review process.
 
 You **SHOULD NOT** draft an MIP, if any of the following are true:
+
 - You only intend to request a change to software units or processes without overseeing specification and review.
-- The change is trivial. In the event that an MIP is required by governance, such trivial changes usually be handled as either errata or appendices of an existing MIP. 
+- The change is trivial. In the event that an MIP is required by governance, such trivial changes usually be handled as either errata or appendices of an existing MIP.
 
 ## Movement Glossary (MG)
 
@@ -39,45 +41,41 @@ See [MG-0](./MIP/mg-0) to get started. A template is provided at [mg-template](m
 
 An alphabetically ordered list of terms is provided in the [glossary](GLOSSARY.md).
 
-MG serve to capture the **definitions** of terms introduced in the MIPs and MDs. The creation of a new MG requires an MIP or MG (since new terms are introduced through the MIP or MG).
-
+MGs serve to capture the **definitions** of terms introduced in the MIPs and MDs. The creation of a new MG requires an MIP or MG (since new terms are introduced through the MIP or MG).
 
 ## Files and numbering
 
 Each MIP, MD or MG is stored in a separate subdirectory with the a name `mip-<number>`, `md-<number>` or `mg-<number>`. The subdirectory contains a `README.md` that describes the MIP, MD, or MG. All assets related to the MIP, MD or MG are stored in the same subdirectory.
 
-MIP/MG start as Drafts. They do not need to acquire a number at this point. 
+An MIP/MD starts as **Draft**s. They DO NOT acquire a number at this point.
 
-MIPs, MDs and MGs are assigned their PR number as soon as they are in the review process. MDs that do not introduce a new MIP are also accepted. Thus, there will be gaps in the MIP number sequence. These gaps will also emerge when MIPs are deprecated or rejected.
+An MIP/MD is assigned their PR number as soon as they are in the **Review** process. MDs that do not introduce a new MIP/MD are also accepted. Thus, there will be gaps in the MIP/MD number sequence. These gaps will also emerge when MIPs/MDs are deprecated or rejected.
 
-PRs that don't introduce a new MIP are also accepted. 
-
-MIPs can be updated. PRs that update a MIP should state so in the PR title via `[Update] .... `. 
+PRs that don't introduce a new MIP/MD are also accepted, for example MIPs/MDs can be updated. PRs that **Update** a MIP/MD should state so in the PR title, e.g. `[Update] MIP-.... `.
 
 ## Status Terms
 
-An MIP is proposed through a PR. Each MIP-introducing PR should have a status in the name in the form `[Status] ...`.
+An MIP/MD is proposed through a PR. Each MIP/MDG-introducing PR should have a status in the name in the form `[Status] ...`.
 
 An MIP/MG should at all times have one of the following statuses:
 
-- **Draft** - (set by author) An MIP/MG that is open for consideration. (It does not yet hold an MIP/MG number)
-- **Review** - (set by author) The MIP/MG is under peer review. The MIP should receive an **MIP number**, according to the rules described in the [Files and numbering](#files-and-numbering) section. At this point the editor should be involved to ensure the MIP adheres to the guidelines.
+- **Draft** - (set by author) An MIP/MD that is open for consideration. (It does not yet hold an MIP/MD number)
+- **Review** - (set by author) The MIP/MD is under peer review. The MIP/MD should receive an **MIP/MD number**, according to the rules described in the [Files and numbering](#files-and-numbering) section. At this point the editor should be involved to ensure the MIP/MD adheres to the guidelines.
 
 >[!Note]
 > In case the editors are not available for an unacceptable long period of time, a reviewer should assume the role of the editor interim.
 
-After acceptance the MIP is merged into `main` and the branch should be deleted.
+After acceptance the MIP/MD is merged into `main` and the branch should be deleted.
 
-Additionally, the following statuses are used for MIPs that are not actively being worked on:
+Additionally, the following statuses are used for MIPs/MDs that are not actively being worked on:
 
-- **Stagnant** - an MIP that has not been updated for 6 months.
-- **Withdrawn** - an MIP that has not been withdrawn.
+- **Stagnant** - an MIP/MD that has not been updated for 6 months.
+- **Withdrawn** - an MIP/MD that has not been withdrawn.
 
 
 Finally, MIPs can also be updated
 
-- **Update** - (set by author) An MIP is being updated. The titel should list the MIP number, e.g. `[Update] MIP-0 ...`.
-
+- **Update** - (set by author) An MIP/MD is being updated. The title should list the MIP/MD number, e.g. `[Update] MIP-0 ...`.
 
 ## Editor
 
@@ -87,10 +85,10 @@ Currently the editors are [@apenzk](https://github.com/apenzk).
 
 The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
 
-- Ensures a high quality of the MIPs, e.g. checking language while reviewing.
-- Removes content from the MIPs that is commented out. (<!- ->)
-- Ensures the MIP numbering is correct, the MIP has been added to [OVERVIEW.md](./OVERVIEW.md)
-- Ensures the MIP is in the correct status.
+- Ensures a high quality of the MIPs/MDs, e.g. checking language while reviewing.
+- Removes content from the MIPs/MDs that is commented out. (e.g. content within <!- -> brackets)
+- Ensures the MIP/MD numbering is correct.
+- Ensures the MIP/MD is in the correct status.
 - Ensures the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS), see [Code owners](#code-owners).
 
 The editor is not responsible for the content.
@@ -100,8 +98,8 @@ The editor is not responsible for the content.
 - the editor can mandate that the author implements the changes by getting 2 upvotes from reviewers on their discussion comment mentioning the changes.
 - Otherwise the author can merge without the editor requested change.
 
-
 ## Code owners
-An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 
-This is being implemented by adding the author as a code owner in the `.github/CODEOWNERS` file for a given MIP or MD.
+An author commits to becoming the owner of the MIP/MD they propose. This means that for any future changes to the MIP/MD the author will be notified.
+
+This is being implemented by adding the author as a code owner in the `.github/CODEOWNERS` file for a given MIP/MD.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Finally, MIPs can also be updated
 - **Update** - (set by author) An MIP is being updated. The titel should list the MIP number, e.g. `[Update] MIP-0 ...`.
 
 
+## Editor
+
+Currently the editors are [@andyjsbell](https://github.com/andyjsbell), [@l-monninger](https://github.com/l-monninger), [@apenzk](https://github.com/apenzk). Volunteers are welcome.
+
+The editor is responsible for the final review of the MIPs. The editor is responsible for the following:
+- Ensures a high quality of the MIPs.
+- Removes content from the MIPs that is commented out. (<!- ->)
+- Ensures the MIP numbering is correct, the MIP has been added to [OVERVIEW.md](./OVERVIEW.md), the MIP is in the correct status and the authors have added themselves to [CODEOWNERS](./.github/CODEOWNERS).
+
+
 ## Code owners
 An author commits to becoming the owner of the MIP or MD they propose. This means that for any future changes to the MIP or MD the author will be notified. 
 


### PR DESCRIPTION
# Summary

**Editors**. This PR introduces editors as an additional actor in the system and who takes responsibility to help with the process of MIPs.

**Status terms**. To identify the different stages already from the PR title, certain status terms are introduced.
 
There is also a need for an overview of existing MIPs. This PR is a prelude for the overview introduced in [this PR](https://github.com/movementlabsxyz/MIP/pull/31).

## Motivation

The distribution of MIP number seems confusing at times and errors may occur.  Contributors may feel hindered by the barrier of MIP-numbering. Furthermore there are a few steps such as correct naming of files or adding editors names to certain files that may not be obvious.

EIP has a well established standard : [https://eips.ethereum.org/](https://eips.ethereum.org/). However, the standard is too complex. Furthermore, the standard relies on a filtering process through a forum, which we do not have.

Inspired by EIP, this PR introduces a modification that can be handled in a small team, yet provides a clear path towards a well managed status of existing MIPs.

In addition it introduces the editor role to support the process.