### PR TITLE
[fix] typos in documentation files

### DIFF
--- a/MD/md-0/README.md
+++ b/MD/md-0/README.md
@@ -46,7 +46,7 @@ Provide definitions that you think will empower the reader to quickly dive into 
 ### D1: Draft and publish standardized proposals
 **User Journey**: Proposer/Researcher can adhere to a standardized template for proposing changes to Movement technologies.
 
-**Justification**: Offering a standardized means for researching a proposing changes to Movement technologies will help guide research both in written structure and by facilitating engagment. The likelihood of producing successful proposals from such a structure should be expected to be higher than otherwise.
+**Justification**: Offering a standardized means for researching a proposing changes to Movement technologies will help guide research both in written structure and by facilitating engagement. The likelihood of producing successful proposals from such a structure should be expected to be higher than otherwise.
 
 ### D2: Implement against clear and accountable specifications
 **User Journey**: Developers can confidently implement complex systems against a clear and accountable specification.

--- a/MIP/mip-0/README.md
+++ b/MIP/mip-0/README.md
@@ -37,11 +37,11 @@ This MIP is correct insofar as it uses a structure established by Ethereum for I
 
 2. **Security Implications**: Each MIP should be evaluated for any potential security risks it might introduce to Movement technologies.
 
-The primary security concern associated with this MIP is the exposure of proprietary techologies or information via the ill-advised formation of an MIP which the MIP process might encourage.
+The primary security concern associated with this MIP is the exposure of proprietary technologies or information via the ill-advised formation of an MIP which the MIP process might encourage.
 
 3. **Performance Impacts**: The implications of the proposal on system performance should be analyzed.
 
-The primarry performance concern associated with this MIP is its potential for overuse. Only specifications that are non-trivial and very high-quality should be composed as MIPs.
+The primary performance concern associated with this MIP is its potential for overuse. Only specifications that are non-trivial and very high-quality should be composed as MIPs.
 
 4. **Validation Procedures**: To the extent possible, formal, analytical, or machined-aided validation of the above should be pursued. 
 
@@ -49,7 +49,7 @@ I'm using spellcheck while writing this MIP. You can verify that I am using vali
 
 5. **Peer Review and Community Feedback**: A section should be included that captures significant feedback from the community, which may influence the final specifications of the MIP.
 
-The Movement Labs team is currently reviewing and assessig this process.
+The Movement Labs team is currently reviewing and assessing this process.
 
 ## Errata
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `engagment` to `engagement`
Corrected `techologies` to `technologies`
Corrected `primarry` to `primary`
Corrected `assessig` to `assessing`


Please review the changes and let me know if any additional changes are needed.
