### PR TITLE
fix: anchor text for MIP Book link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ graph LR
 The [Glossary](https://github.com/movementlabsxyz/MIP/wiki/glossary) contains an alphabetically ordered list of terms used in this repository. 
 In addition MG serves as a platform to define glossary terms, which are used in the MIPs and MDs.
 
-> :bulb: For more information on the process in this repository, see also[MIP-0](./MIP/mip-0/README.md).
+> :bulb: For more information on the process in this repository, see also [MIP-0](./MIP/mip-0/README.md).
 
 ## Movement Desiderata (MD)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 We differentiate between **issue**, **MD** and **MIP**.
 
-An overview of the MIPs and MDs can be found in the [OVERVIEW](https://movementlabsxyz.github.io/MIP/).
+A user-friendly overview of the MIPs and MDs can be found in the [MIP Book](https://movementlabsxyz.github.io/MIP/).
 
 The lifecycle of a proposal should be:
 


### PR DESCRIPTION
# Summary

See #107.

There's a link to the MIP Book in the readme but it's hard to find due to being mislabeled as "overview".