### PR TITLE
docs: mark repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!WARNING]
+> **This repository is deprecated.** Active development has moved to [MoveIndustries/MIP](https://github.com/MoveIndustries/MIP). Please open new issues and PRs there.
 
 # MIP, MD and MG
 


### PR DESCRIPTION
## Summary
- Add a warning banner at the top of the README marking this repository as deprecated and pointing to [MoveIndustries/MIP](https://github.com/MoveIndustries/MIP).
